### PR TITLE
support direct source loading like a webpack loader

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,45 @@ const Sketch = require('./src/Sketch');
 
 (function(lib) {
     /**
+     * Load the source content of a sketch file and return a promise with
+     * a Sketch instance
+     * @alias load
+     * @param {String} source - Content of a sketch file
+     *
+     * @return {Promise}
+     */
+    lib.load = function(source) {
+        return JSZip.loadAsync(source)
+            .then(zip => {
+                return Promise.all([
+                    zip.file('document.json').async('string'),
+                    zip.file('meta.json').async('string'),
+                    zip.file('user.json').async('string')
+                ]).then(result => {
+                    return {
+                        repo: zip,
+                        document: JSON.parse(result[0]),
+                        meta: JSON.parse(result[1]),
+                        user: JSON.parse(result[2])
+                    };
+                });
+            })
+            .then(data => {
+                return Promise.all(
+                    data.document.pages.map(page => {
+                        return data.repo.file(`${page._ref}.json`).async('string');
+                    })
+                ).then(pages => {
+                    data.pages = pages.map(page => JSON.parse(page));
+                    return data;
+                });
+            })
+            .then(data => {
+                return new Sketch(data.repo, data.document, data.meta, data.user, data.pages);
+            });
+    };
+
+    /**
      * Read a sketch file and returns a promise with a Sketch instance
      * @alias read
      * @param  {Array|String} file - Can be a path or an array of paths
@@ -33,34 +72,7 @@ const Sketch = require('./src/Sketch');
             return Promise.all(file.map(each => lib.read(each)));
         }
 
-        return JSZip.loadAsync(fs.readFileSync(file))
-            .then(zip => {
-                return Promise.all([
-                    zip.file('document.json').async('string'),
-                    zip.file('meta.json').async('string'),
-                    zip.file('user.json').async('string')
-                ]).then(result => {
-                    return {
-                        repo: zip,
-                        document: JSON.parse(result[0]),
-                        meta: JSON.parse(result[1]),
-                        user: JSON.parse(result[2])
-                    };
-                });
-            })
-            .then(data => {
-                return Promise.all(
-                    data.document.pages.map(page => {
-                        return data.repo.file(`${page._ref}.json`).async('string');
-                    })
-                ).then(pages => {
-                    data.pages = pages.map(page => JSON.parse(page));
-                    return data;
-                });
-            })
-            .then(data => {
-                return new Sketch(data.repo, data.document, data.meta, data.user, data.pages);
-            });
+        return lib.load(fs.readFileSync(file));
     };
 
     const Node = require('./src/Node');


### PR DESCRIPTION
How about exposing a method of the tool itself, where developers can load source directly and act like a webpack loader?